### PR TITLE
Fix aliases trailing line

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Parameters
 * **aliases**: hash of aliases. Example: { 'user' => 'email' }
 * **generics_domains**: list of domains to serve. Example: [ 'domain1.com', 'domain2.com' }
 * **generics_table**: hash of user email addresses for multiple domains. Example: { 'user', 'email' }
-
+* **is_relay**: bool, set to 1 if you want the server to be a relay
+* **relay-domains**: list of domains to relay for. Example: { 'example.com', 'example2.co.uk' }
+* **listen_ip**: Single IP address that the server should listen on. Example: 127.0.0.1
 
 Usage
 -----
@@ -47,6 +49,11 @@ Contributors
 
 Release Notes
 -------------
+
+**0.1.3**
+
+* Added relayer functionality
+* Added listen_ip setting
 
 **0.1.2**
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,15 @@
 # [*generics_table*]
 #   Hash of user email addresses for multiple domains. Example: { 'user', 'email' }
 #
+# [*listen_ip*]
+#   Specifies if sendmail should listen on an ip other than localhost. Example: 127.0.0.1
+#
+# [*is_relay*]
+#   Specifies if sendmail should relay email from other servers. Boolean
+#
+# [*relay_domains*]
+#   List of domains to relay email for. Example: ['example.com','example2.co.uk']
+#
 # === Examples
 #
 #  class { sendmail:
@@ -69,6 +78,9 @@ class sendmail (
   $aliases                  = undef,
   $generics_domains         = undef,
   $generics_table           = undef,
+  $listen_ip                = '127.0.0.1',
+  $is_relay                 = undef,
+  $relay_domains            = $sendmail::params::relay_domains
 ) inherits sendmail::params {
     package { $sendmail::params::sendmail_pkgs: ensure => latest }
 
@@ -78,7 +90,7 @@ class sendmail (
         mode    => '0644',
         content => template($sendmail::params::sendmail_mc_tmpl),
         require => Package[$sendmail::params::sendmail_pkgs],
-        notify  => Exec ["make_sendmail_config"],
+        notify  => Exec["make_sendmail_config"],
     }
 
     if ($aliases) {
@@ -93,7 +105,20 @@ class sendmail (
     } else {
         file { $sendmail::params::aliases_path: ensure => absent, notify => Service[$sendmail::service_name] }
     }
-
+    
+    if ($is_relay) {
+        file { $sendmail::params::relay_domains_path:
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0644',
+            content => template($sendmail::params::relay_domains_tmpl),
+            require => Package[$sendmail::params::sendmail_pkgs],
+            notify  => Service[$sendmail::service_name],
+        }
+    } else {
+        file { $sendmail::params::relay_domains_path: ensure => absent, notify => Service[$sendmail::service_name] }
+    }
+    
     if ($generics_domains) {
         file { $sendmail::params::generics_domains_path:
             owner   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,9 +4,14 @@ class sendmail::params {
   $sendmail_mc_tmpl      = 'sendmail/sendmail.mc.erb'
   $aliases_path          = '/etc/mail/aliases'
   $aliases_tmpl          = 'sendmail/aliases.erb'
+  $relay_domains_path    = '/etc/mail/relay-domains'
+  $relay_domains_tmpl    = 'sendmail/relay-domains.erb'
+  $is_relay              = 'sendmail/relay-domains.erb'
+  $relay_domains         = ['example.com', 'example.co.uk']
   $generics_domains_path = '/etc/mail/generics-domains'
   $generics_domains_tmpl = 'sendmail/generics-domains.erb'
   $generics_table_path   = '/etc/mail/genericstable'
   $generics_table_tmpl   = 'sendmail/genericstable.erb'
   $service_name          = 'sendmail'
+  $listen_ip              = '127.0.0.1'
 }

--- a/templates/aliases.erb
+++ b/templates/aliases.erb
@@ -1,3 +1,3 @@
 <% scope.lookupvar('sendmail::aliases').sort.each do |user,email| -%>
 <%= user %>:    <%= email %>
-<% end -%> 
+<% end -%>

--- a/templates/relay-domains.erb
+++ b/templates/relay-domains.erb
@@ -1,0 +1,3 @@
+<% scope.lookupvar('sendmail::relay_domains').each do |relaydomain| -%>
+<%= relaydomain %>
+<% end -%>

--- a/templates/sendmail.mc.erb
+++ b/templates/sendmail.mc.erb
@@ -123,7 +123,7 @@ dnl # The following causes sendmail to only listen on the IPv4 loopback address
 dnl # 127.0.0.1 and not on any other network devices. Remove the loopback
 dnl # address restriction to accept email from the internet or intranet.
 dnl #
-DAEMON_OPTIONS(`Port=smtp,Addr=127.0.0.1, Name=MTA')dnl
+DAEMON_OPTIONS(`Port=smtp,Addr=<%= scope.lookupvar('sendmail::listen_ip') %>, Name=MTA')dnl
 dnl #
 dnl # The following causes sendmail to additionally listen to port 587 for
 dnl # mail from MUAs that authenticate. Roaming users who can't reach their


### PR DESCRIPTION
Hi Alessandro,

you have a little typo in the aliases.erb template: a space after the closing <% end -%> that makes ERB output an empty line at the end of the file. That makes makemap quite upset ;)

Please find attached the PR that fixes the issue (I'm sorry it also includes 73bdbe0735184d67e2788a0137e2bda13d3b7180 from @abaxo)